### PR TITLE
[FEAT]MAIN 컴포넌트 수정 및 메인페이지 태그 버튼

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,10 +17,6 @@
 }
 
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
 
 @media (prefers-reduced-motion: no-preference) {
   .App-logo {
@@ -47,18 +43,3 @@
   color: #61dafb;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-.start {
-  transform: scale(0);
-}
-.end {
-  transform: scale(1);
-  transition: opacity 0.5s;
-}

--- a/src/App.js
+++ b/src/App.js
@@ -13,15 +13,28 @@ import NavBar2 from './components/NavBar2';
 import Review from './pages/Review';
 import MyPageDetail from './pages/ReviewDetail';
 import Main from './pages/Main';
+import AllFamous from './pages/AllFamous';
+import AllNew from './pages/AllNew';
+import AllTagRegion from './pages/AllTagRegion';
 
 
 function App() {
-
+  let [shoes, setShoes] = useState(data);
   return (
     <div className="App">
       
       <NavBar2></NavBar2>
-      <Main></Main>
+      <Routes>
+        <Route path='/' element={<Main/>}></Route>
+        <Route path='/mypage' element={<MyPage shoes={shoes}/>}></Route>
+        <Route path="/info" element={<Info></Info>}></Route>
+        <Route path="/mypage/detail" element={ <MyPageDetail shoes={shoes}/> }/>
+        <Route path='/review' element={<Review/>}></Route>
+        <Route path="/newAll" exact component={<AllNew></AllNew>} />
+        <Route path="/famousAll" component={<AllFamous></AllFamous>} />
+        <Route path="/tagregionAll" component={<AllTagRegion></AllTagRegion>} />
+      </Routes>
+
       
     </div>
   );

--- a/src/components/TagButton.js
+++ b/src/components/TagButton.js
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
+function TagButton({text, to}) {
+  return (
+    <>
+      <StyledButton>
+      <Link to={to}>{text}</Link>
+      </StyledButton>
+    </>
+  );
+}
+
+export default TagButton;
+
+const StyledButton = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 20px;
+  gap: 10px;
+  width: 289px;
+  height: 65px;
+  background: #FFFAC9;
+  border: 1px solid #000000;
+  border-radius: 30px;
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+  fontSize: 14, 
+  fontWeight: 'normal'
+`;
+

--- a/src/components/TagButton.js
+++ b/src/components/TagButton.js
@@ -4,8 +4,8 @@ import { Link } from 'react-router-dom';
 function TagButton({text, to}) {
   return (
     <>
-      <StyledButton>
-      <Link to={to}>{text}</Link>
+      <StyledButton to={to}>
+      <span>{text}</span>
       </StyledButton>
     </>
   );
@@ -29,7 +29,8 @@ const StyledButton = styled.div`
   flex: none;
   order: 0;
   flex-grow: 0;
-  fontSize: 14, 
-  fontWeight: 'normal'
+  fontSize: 20;
+  fontWeight: 'normal';
+  cursor: pointer;
 `;
 

--- a/src/pages/AllFamous.js
+++ b/src/pages/AllFamous.js
@@ -1,0 +1,9 @@
+/*인기 전체보기 페이지*/
+function Main(){
+    
+    return(
+    <div className='Wrapper'>
+    </div>
+    );
+  }
+  export default Main;

--- a/src/pages/AllNew.js
+++ b/src/pages/AllNew.js
@@ -1,0 +1,9 @@
+/*신규 전체보기 페이지*/
+function Main(){
+    
+    return(
+    <div className='Wrapper'>
+    </div>
+    );
+  }
+  export default Main;

--- a/src/pages/AllTagRegion.js
+++ b/src/pages/AllTagRegion.js
@@ -1,0 +1,9 @@
+/*관심 태그&지역 전체보기 페이지*/
+function Main(){
+    
+    return(
+    <div className='Wrapper'>
+    </div>
+    );
+  }
+  export default Main;

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -11,33 +11,41 @@ import ControlledCarousel from '../components/Carousel';
 import NavBar2 from '../components/NavBar2';
 import Review from './Review';
 import MyPageDetail from './ReviewDetail';
-function Main(props){
+import TagButton from '../components/TagButton.js';
+import styled from 'styled-components';
+function Main(){
     let [shoes, setShoes] = useState(data);
     let [재고] = useState([10,11,12]);
     let navigate = useNavigate();
     return(
     <div className='Wrapper'>
-    <Routes>
-      <Route path='/' element={
-      <div>
-          <div className="container">
-            <ControlledCarousel></ControlledCarousel>
-            </div>
-        </div>
-        }>
-      </Route>
+      <ControlledCarousel/>
+        <HeaderWrapper>
+          <h3>  님! 어떤 봉사정보 추천을 원하시나요?{'\n'}</h3>
+        </HeaderWrapper>
+        <ButtonWrapper>
+        <TagButton text="관심 태그 & 지역" to="/interest-tags"></TagButton>
+        <TagButton text="신규" to="/new"></TagButton>
+        <TagButton text="인기" to="/popular"></TagButton>
+        </ButtonWrapper>
+      
 
-      <Route path='/mypage' element={<MyPage shoes={shoes}/>}></Route>
-      <Route path="/info" element={<Info></Info>}></Route>
-      <Route path="/mypage/detail" element={ <MyPageDetail shoes={shoes}/> }/>
-      <Route path='/review' element={<Review/>}>
-        <Route path='member' element={<div>멤버들</div>}></Route>
-        <Route path='location' element={<div>회사위치</div>}></Route>
-      </Route>
-
-
-    </Routes>
     </div>
     );
   }
   export default Main;
+
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  padding: 20px 0px 16px;
+  gap: 10px;
+`;
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+`;
+
+

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -24,9 +24,9 @@ function Main(){
           <h3>  님! 어떤 봉사정보 추천을 원하시나요?{'\n'}</h3>
         </HeaderWrapper>
         <ButtonWrapper>
-        <TagButton text="관심 태그 & 지역" to="/interest-tags"></TagButton>
+        <TagButton text="관심 태그 & 지역" to="/tagregionAll"></TagButton>
         <TagButton text="신규" to="/new"></TagButton>
-        <TagButton text="인기" to="/popular"></TagButton>
+        <TagButton text="인기" to="/famousAll"></TagButton>
         </ButtonWrapper>
       
 


### PR DESCRIPTION
## PR Summary
- <App.js> routes들이 올 수 있도록 수정, navbar는 다른 페이지들도  사용하므로 그대로 나둠
- main.js 컴포넌트 수정
- 메인페이지의 광고창 아래 버튼 구현


## PR Detail
- 


## Screenshot
- 
![image](https://github.com/DowaDream/DowaDream-Web/assets/101245448/a509b1d2-49f0-455e-ba5c-3cca6c6004d0)





## CheckList
- [ o] 해당 프로젝트가 최신 상태임을 확인했나요? (`git pull` 명령어를 통해 충돌 사항을 확인해주세요!)
- [ o] Build가 잘되는지 확인했나요? (`npm run build`)
- [ o] 주석처리된 코드가 없나요? (있다면, 아래에 세부사항 작성 부탁드려요 !)


## Reference
