### PR TITLE
[FEAT] Info전체정보 수정

### DIFF
--- a/src/components/Home/InfoTitle.js
+++ b/src/components/Home/InfoTitle.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 
@@ -9,6 +10,9 @@ const text = [
 ];
 
 const InfoTitle = ({ num }) => {
+
+  const navigate = useNavigate();
+
   return (
     <>
       {num === 1 ? (
@@ -20,7 +24,7 @@ const InfoTitle = ({ num }) => {
         <TitleTextOthers>{text[num - 1]}</TitleTextOthers>
       )}
       
-        <TiteViewAll>전체보기</TiteViewAll>
+        <TiteViewAll onClick={()=>{navigate('/info')}}>전체보기</TiteViewAll>
 
     </>
   );

--- a/src/components/Maininfo/InfoSelectionList.js
+++ b/src/components/Maininfo/InfoSelectionList.js
@@ -22,33 +22,29 @@ const Area = [
   ["제주", "제주시", "서귀포시"],
 ];
 
-
-
 const InfoSelectionList = (props) => {
 
 
 
-
-  const { isSelectLoc, SetIsSelectLoc, detailButtonStates, setDetailButtonStates } = props;  // 수정된 부분
+  const { isSelectLoc, SetIsSelectLoc, detailButtonStates,setDetailButtonStates,allInfo,setAllInfo } = props;  // 수정된 부분
   const x = (Area[isSelectLoc].length % 4);
 
-  useEffect(() => {
-    const ResetDetailButtonState = () => {
-      const updatedStates = Array.from({ length: detailButtonStates.length }).fill(false);
-      setDetailButtonStates(updatedStates);
-    };
-  
-    ResetDetailButtonState();
-  }, [isSelectLoc]);
-  
 
 
   const toggleDetailButtonState = (index) => {
     const updatedStates = [...detailButtonStates];
-    updatedStates[index] = !updatedStates[index];
-    setDetailButtonStates(updatedStates);
-  };
+    const updatedAllInfo = [...allInfo];
 
+    if(updatedStates[index] !==false){
+      updatedStates[index] = false;
+    }
+    else{
+      updatedStates[index] = Area[isSelectLoc][index];
+    }
+    updatedAllInfo[isSelectLoc] = [Area[isSelectLoc][0], updatedStates];
+    setDetailButtonStates(updatedStates);
+    setAllInfo(updatedAllInfo);
+  };
 
 
   return (
@@ -70,7 +66,7 @@ const InfoSelectionList = (props) => {
       {
         Area[isSelectLoc].map((area, index) => (
           <LocDetailDiv onClick={() => toggleDetailButtonState(index)} key={area}>
-            <LocDetailButton states={detailButtonStates[index].toString()} />
+          <LocDetailButton states={detailButtonStates[index].toString()} />
             <LocDetailText>{area}</LocDetailText>
           </LocDetailDiv>
         ))

--- a/src/components/MyTags.js
+++ b/src/components/MyTags.js
@@ -7,11 +7,33 @@ const Tag = [
   "공익, 인권","교육","국제행사","국제협력, 해외봉사","농어촌 봉사", "문화행사", "멘토링", "보건의료","상담","생활편의지원","안전, 예방","자원봉사교육","재해, 재난","주거환경","행정보조","환경보호","기타"
 ];
 
+const AreaFirstElements = [
+  "전국",
+  "서울",
+  "경기",
+  "인천",
+  "부산",
+  "대구",
+  "광주",
+  "대전",
+  "울산",
+  "세종",
+  "강원",
+  "경남",
+  "경북",
+  "전남",
+  "전북",
+  "충남",
+  "충북",
+  "제주"
+]
+
 function MyTags(){
 
   const [isSelectLoc,setIsSelectLoc] = useState("1");
   const [detailButtonStates, setDetailButtonStates] = useState(Array.from({ length: 33 }).fill(false));
   const [isTagDetailStates, setTagDetailState] = useState(Array.from({length : 20}).fill(false))
+  const [allInfo, setAllInfo] = useState(AreaFirstElements,Array.from({ length: 33 }).fill(false));
 
   const onLocListClicked = (name) =>{
     setIsSelectLoc(`${name}`);
@@ -21,6 +43,22 @@ const toggleTagDetailButtonState = (index) => {
   updatedStates[index] = !updatedStates[index];
   setTagDetailState(updatedStates);
 };
+const onTotalInfoClicked = () =>{
+
+  allInfo.forEach((info, index) => {
+      const firstElement = info[0];
+      if(info[1].length!==1){
+          const secondArray = info[1];
+
+      const nonFalseValues = secondArray.filter(value => value !== false);
+
+      console.log(`First Element: ${firstElement}`);
+      console.log(`Non-False Values: ${nonFalseValues}`);
+      }
+    });
+
+}
+
 
     return (
       <>
@@ -47,7 +85,9 @@ const toggleTagDetailButtonState = (index) => {
                 isSelectLoc={isSelectLoc}
                 SetIsSelectLoc={onLocListClicked}
                 detailButtonStates={detailButtonStates}
-                setDetailButtonStates={setDetailButtonStates} // 수정된 부분: setdetailButtonStates가 아니라 setDetailButtonStates
+                setDetailButtonStates={setDetailButtonStates}
+                allInfo={allInfo}
+                setAllInfo={setAllInfo} // 수정된 부분: setdetailButtonStates가 아니라 setDetailButtonStates
               ></InfoSelectionList>
               <LocDeletediv>
                 <LocDeleteText>지역</LocDeleteText>
@@ -55,7 +95,7 @@ const toggleTagDetailButtonState = (index) => {
               </LocDeletediv>
           </LocWrapper>
           <Link to="/mypage/save">
-            <SaveButton>모두 저장하기</SaveButton>
+            <SaveButton onClick={onTotalInfoClicked}>모두 저장하기</SaveButton>
           </Link>
 
 

--- a/src/pages/Info/MainInfo.js
+++ b/src/pages/Info/MainInfo.js
@@ -13,7 +13,30 @@ const StArray= [
     "없음",
 ]
 
-const arr = Array.from({ length: 19 }).fill(false);
+const Area = [
+    ["전국"],
+    ["서울", "종로구", "중구", "용산구", "성동구", "광진구", "동대문구", "중랑구", "성북구", "강북구", "도봉구", "노원구", "은평구", "서대문구", "마포구", "양천구", "강서구", "구로구", "금천구", "영등포구", "동작구", "관악구", "서초구", "강남구", "송파구", "강동구"],
+    ["경기", "수원시", "성남시", "고양시", "용인시", "부천시", "안산시", "안양시", "남양주시", "화성시", "평택시", "의정부시", "시흥시", "파주시", "광명시", "김포시", "군포시", "광주시", "이천시", "양주시", "오산시", "구리시", "안성시", "포천시", "의왕시", "하남시", "여주시", "양평군", "동두천시", "과천시", "가평군", "연천군"],
+    ["인천", "중구", "동구", "미추홀구", "연수구", "남동구", "부평구", "계양구", "서구", "강화군", "옹진군"],
+    ["부산", "중구", "서구", "동구", "영도구", "부산진구", "동래구", "남구", "북구", "해운대구", "사하구", "금정구", "강서구", "연제구", "수영구", "사상구", "기장군"],
+    ["대구", "중구", "동구", "서구", "남구", "북구", "수성구", "달서구", "달성군", "군위군"],
+    ["광주", "동구", "서구", "남구", "북구", "광산구"],
+    ["대전", "동구", "중구", "서구", "유성구", "대덕구"],
+    ["울산", "중구", "남구", "동구", "북구", "울주군"],
+    ["세종", "세종시"],
+    ["강원", "춘천시", "원주시", "강릉시", "동해시", "태백시", "속초시", "삼척시", "횡성군", "영월군", "평창군", "정선군", "철원군", "화천군", "양구군", "인제군", "고성군", "양양군"],
+    ["경남", "창원시", "진주시", "통영시", "사천시", "김해시", "밀양시", "거제시", "양산시", "의령군", "함안군", "창녕군", "고성군", "남해군", "하동군", "산청군", "함양군", "거창군", "합천군"],
+    ["경북", "포항시", "경주시", "김천시", "안동시", "구미시", "영주시", "영천시", "상주시", "문경시", "경산시", "의성군", "청송군", "영양군", "영덕군", "청도군", "고령군", "성주군", "칠곡군", "예천군", "봉화군", "울진군", "울릉군"],
+    ["전남", "목포시", "여수시", "순천시", "나주시", "광양시", "담양군", "곡성군", "구례군", "고흥군", "보성군", "화순군", "장흥군", "강진군", "해남군", "영암군", "무안군", "함평군", "영광군", "장성군", "완도군", "진도군", "신안군"],
+    ["전북", "전주시", "군산시", "익산시", "정읍시", "남원시", "김제시", "완주군", "진안군", "무주군", "장수군", "임실군", "순창군", "고창군", "부안군"],
+    ["충남", "천안시", "공주시", "보령시", "아산시", "서산시", "논산시", "계룡시", "당진시", "금산군", "부여군", "서천군", "청양군", "홍성군", "예산군", "태안군"],
+    ["충북", "청주시", "충주시", "제천시", "보은군", "옥천군", "영동군", "증평군", "진천군", "괴산군", "음성군", "단양군"],
+    ["제주", "제주시", "서귀포시"],
+  ];
+
+  const arr = Array.from({length : 18}).fill(false);
+  
+  const AreaFirstElements = Area.map(area => area[0]);
 
 
 
@@ -28,9 +51,9 @@ const MainInfo = () => {
     //지역 및 세부 주소
     const [isSelectLoc,setIsSelectLoc] = useState("1");
     const [detailButtonStates, setDetailButtonStates] = useState(Array.from({ length: 33 }).fill(false));
-    
-    const [isSelectTag, setIsSelectTag] = useState(Array.from({ length: 22 }).fill(false));
 
+    const [isSelectTag, setIsSelectTag] = useState(Array.from({ length: 22 }).fill(false));
+    const [allInfo, setAllInfo] = useState(AreaFirstElements,Array.from({ length: 33 }).fill(false));
     const onToggle = () => setIsOpen(!isOpen);
     
     const onOptionClicked = (value, i) => () => {
@@ -44,11 +67,39 @@ const MainInfo = () => {
       setIsOpen(false);
     };
 
-
-    const onLocListClicked = (name) =>{
+    const onLocListClicked = (name) => {
+        const updatedAllInfo = [...allInfo];
+        updatedAllInfo[isSelectLoc] = [Area[isSelectLoc][0], detailButtonStates];
+        if (allInfo[name][1].length !== 1) {
+            setDetailButtonStates(updatedAllInfo[name][1]);
+        } else if (name !== isSelectLoc) {
+            setDetailButtonStates(Array.from({ length: 33 }).fill(false));
+        } else if (name === isSelectLoc) {
+            setDetailButtonStates(updatedAllInfo[name][1]);
+        }
+    
         setIsSelectLoc(`${name}`);
+        setAllInfo(updatedAllInfo);
+    }
+    
+
+    const onTotalInfoClicked = () =>{
+
+        allInfo.forEach((info, index) => {
+            const firstElement = info[0];
+            if(info[1].length!==1){
+                const secondArray = info[1];
+      
+            const nonFalseValues = secondArray.filter(value => value !== false);
+      
+            console.log(`First Element: ${firstElement}`);
+            console.log(`Non-False Values: ${nonFalseValues}`);
+            }
+          });
+
     }
 
+      
   return (
     <Wrapper>
         
@@ -63,11 +114,13 @@ const MainInfo = () => {
                 isSelectLoc={isSelectLoc}
                 SetIsSelectLoc={onLocListClicked}
                 detailButtonStates={detailButtonStates}
-                setDetailButtonStates={setDetailButtonStates} // 수정된 부분: setdetailButtonStates가 아니라 setDetailButtonStates
+                setDetailButtonStates={setDetailButtonStates}
+                allInfo ={allInfo}
+                setAllInfo={setAllInfo}
                 />
                 : <InfoSelectionTagList isSelectTag={isSelectTag} setIsSelectTag={setIsSelectTag}></InfoSelectionTagList>
             }            
-            <SearchInfo> <img alt={name} src={Search}/><div>선택 조건으로 검색하기</div></SearchInfo>
+            <SearchInfo onClick={onTotalInfoClicked}> <img alt={name} src={Search}/><div>선택 조건으로 검색하기</div></SearchInfo>
         
         </InfoSelection>
 

--- a/src/pages/Info/MainInfo.js
+++ b/src/pages/Info/MainInfo.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Wrapper } from '../../styles/Common'
 import styled from 'styled-components'
 import DropDown from '../../components/DropDown';
@@ -41,6 +41,11 @@ const Area = [
 
 
 const MainInfo = () => {
+
+    useEffect(() => {
+        // 컴포넌트가 마운트되면 스크롤을 맨 위로 이동시킴
+        window.scrollTo(0, 0);
+    }, []); // 빈 배열을 전달하면 컴포넌트가 마운트될 때 한 번만 실행됨
 
     const x = 1;
     


### PR DESCRIPTION
## PR Summary
- Info전체 정보 리턴 가능하게 수정했습니다.


## PR Detail
- 원래는 좀더 효율적으로 짜보려고 했는데, 잘 안되서 그냥 useState로 상태 3개 받아서, 각각 지역, 지역 세부,전체로 구현하였습니다.
- 사용되는 오브젝트에 각각 해당 상태 추가하여 풀리퀘 날립니다.


## Screenshot
- 
![image](https://github.com/DowaDream/DowaDream-Web/assets/100814191/d52b1998-a87a-40a5-82fe-cb06460eab3e)
![image](https://github.com/DowaDream/DowaDream-Web/assets/100814191/29d1da02-f0b7-4a1e-b114-0ec98e43c709)




## CheckList
- [ ] 해당 프로젝트가 최신 상태임을 확인했나요? (`git pull` 명령어를 통해 충돌 사항을 확인해주세요!)
- [ ] Build가 잘되는지 확인했나요? (`npm run build`)
- [ ] 주석처리된 코드가 없나요? (있다면, 아래에 세부사항 작성 부탁드려요 !)


## Reference
